### PR TITLE
Refactor default action 

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "additional_certificates_arns" {
 variable "default_action" {
   type = any
   # type = object({
-  #   # (Required) Type of routing action. Valid values are 'forward', 'redirect', 'fixed-response', 'authenticate-cognito' and 'authenticate-oidc'.
+  #   # (Required) Type of routing action. Valid values are 'forward', 'redirect', 'fixed-response'.
   #   type = string
   #   # (Optional) Order for the action. This value is required for rules with multiple actions. The action with the lowest value for order is performed first. Valid values are between 1 and 50000.
   #   order = optional(number)


### PR DESCRIPTION
As written in the https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener#authenticate-cognito-action, the `aws_lb_listener` may have several `default_action` block if an action such as `forward`, `redirect` or `fixed-response` is  combined with either `authenticate_cognito` or `authenticate_oidc`.

This PR changes the implementation so that potential default authentication actions are create in their own `default_action` block. Still, all actions can be defined through the single `default_action` variable. If accepted, I will apply similar changes to the rules in  #3 